### PR TITLE
fix(deps): pin library versions for stable Streamlit deployment

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pandas
-requests
-streamlit
-streamlit-calendar
+streamlit==1.31.0
+pandas>=2.0.3
+requests>=2.31.0
+streamlit-calendar>=0.0.6


### PR DESCRIPTION
- Streamlit pinned to 1.31.0 to ensure compatibility
- Pandas >=2.0.3 for consistent data handling
- Requests >=2.31.0 for API stability
- Streamlit-Calendar >=0.0.6 to avoid runtime errors
- Altair pin to 4.2.2 (handled previously) resolves ModuleNotFoundError issues